### PR TITLE
Fix resource handling for CSV reader

### DIFF
--- a/collect-earth/collect-earth-core/src/main/java/org/openforis/collect/earth/core/utils/CsvReaderUtils.java
+++ b/collect-earth/collect-earth-core/src/main/java/org/openforis/collect/earth/core/utils/CsvReaderUtils.java
@@ -49,15 +49,16 @@ public class CsvReaderUtils {
 		CSVReader csvReader = null;
 		for (char c : possibleSeparators) {
 			CSVReader commaSeparatedReader = getCsvReader(csvFile, c, skipHeader);
-			if (!checkContainsCoordinates) {
-				return commaSeparatedReader;
-			} else if (checkCsvReaderWorks(commaSeparatedReader)) {
-				csvReader = getCsvReader(csvFile, c, skipHeader); // Get the reader again so that it starts from the
-																	// first column
-				break;
-			} else {
-				commaSeparatedReader.close();
-			}
+                       if (!checkContainsCoordinates) {
+                               return commaSeparatedReader;
+                       } else if (checkCsvReaderWorks(commaSeparatedReader)) {
+                               commaSeparatedReader.close();
+                               csvReader = getCsvReader(csvFile, c, skipHeader); // Get the reader again so that it starts from the
+                                                                               // first column
+                               break;
+                       } else {
+                               commaSeparatedReader.close();
+                       }
 		}
 
 		if (csvReader == null) {


### PR DESCRIPTION
## Summary
- close temporary CSV reader when validating separators

## Testing
- `mvn -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853fbd8d634832d902683bcec0abb00