### PR TITLE
Fix installer: remove double quotes from chown and chmod executions (saiku)

### DIFF
--- a/collect-earth/collect-earth-installer/src/main/resources/CollectEarthWithSaiku.xml
+++ b/collect-earth/collect-earth-installer/src/main/resources/CollectEarthWithSaiku.xml
@@ -86,7 +86,7 @@
 
 				<runProgram>
 					<program>chown</program>
-                    <programArguments>-fR ${system_username}  "${installdir}/saiku-server_2.6"</programArguments>
+                    <programArguments>-fR ${system_username}  ${installdir}/saiku-server_2.6</programArguments>
 					<ruleList>
 						<platformTest>
 							<negate>1</negate>
@@ -96,7 +96,7 @@
 				</runProgram>
 				<runProgram>
 					<program>chmod</program>
-					<programArguments>-R ugo+rwX "${installdir}/saiku-server_2.6"</programArguments>
+					<programArguments>-R ugo+rwX ${installdir}/saiku-server_2.6</programArguments>
 					<ruleList>
 						<platformTest>
 							<negate>1</negate>


### PR DESCRIPTION
When the installer is invoked from the terminal, the `chown` and `chmod` commands were wrapped in **double quotes** ("), which caused issues:

- Paths starting with ~ did not expand correctly to the user’s home directory.

This PR removes the double quotes from the chown and chmod arguments so that:

- ~ expands correctly to the home directory.

In the installer, the `installdir` is hardcoded as `"~/OpenForis"`, so it is safe to remove the double quotes around the path.

_Error reproduced on macOS Sequoia (15.6.1 (24G90))_